### PR TITLE
Completion additions

### DIFF
--- a/capabilities.pas
+++ b/capabilities.pas
@@ -61,11 +61,31 @@ type
   private
     fTextDocumentSync: TTextDocumentSyncOptions;
     fCompletionProvider: TCompletionOptions;
+    fHoverProvider: boolean;
+    fDefinitionProvider: boolean;
+    fDeclarationProvider: boolean;
+    fReferencesProvider: boolean;
+    fImplementationProvider: boolean;
+    fCodeActionProvider: boolean;
+    fDocumentHighlightProvider: boolean;
+    fDocumentSymbolProvider: boolean;
+    fWorkspaceSymbolProvider: boolean;
+    fSignatureHelpProvider: TSignatureHelpOptions;
   public
     constructor Create;
   published
     property textDocumentSync: TTextDocumentSyncOptions read fTextDocumentSync write fTextDocumentSync;
     property completionProvider: TCompletionOptions read fCompletionProvider write fCompletionProvider;
+    property hoverProvider: boolean read fHoverProvider write fHoverProvider;
+    property definitionProvider: boolean read fDefinitionProvider write fDefinitionProvider;
+    property declarationProvider: boolean read fDeclarationProvider write fDeclarationProvider;
+    property referencesProvider: boolean read fReferencesProvider write fReferencesProvider;
+    property implementationProvider: boolean read fImplementationProvider write fImplementationProvider;
+    property codeActionProvider: boolean read fCodeActionProvider write fCodeActionProvider;
+    property documentHighlightProvider: boolean read fDocumentHighlightProvider write fDocumentHighlightProvider;
+    property documentSymbolProvider: boolean read fDocumentSymbolProvider write fDocumentSymbolProvider;
+    property workspaceSymbolProvider: boolean read fWorkspaceSymbolProvider write fWorkspaceSymbolProvider;
+    property signatureHelpProvider: TSignatureHelpOptions read fSignatureHelpProvider write fSignatureHelpProvider;
   end;
 
 implementation
@@ -73,10 +93,16 @@ implementation
 { TServerCapabilities }
 
 constructor TServerCapabilities.Create;
+var
+  triggerCharacters: TStringList;
 begin
   textDocumentSync := TTextDocumentSyncOptions.Create;
+  
   completionProvider := TCompletionOptions.Create;
+  triggerCharacters := TStringList.Create;
+  triggerCharacters.Add('.');
+  triggerCharacters.Add('^');
+  completionProvider.triggerCharacters := triggerCharacters;
 end;
 
 end.
-

--- a/codeUtils.pas
+++ b/codeUtils.pas
@@ -1,5 +1,5 @@
 // Pascal Language Server
-// Copyright 2020 Arjan Adriaanse
+// Copyright 2020 Ryan Joseph
 
 // This file is part of Pascal Language Server.
 

--- a/codeUtils.pas
+++ b/codeUtils.pas
@@ -1,0 +1,136 @@
+// Pascal Language Server
+// Copyright 2020 Arjan Adriaanse
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+unit codeUtils;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  SysUtils, Classes;
+
+function ParseParamList(RawList: String): TStringList; overload;
+function ParseParamList(RawList: String; AsSnippet: boolean): String; overload;
+
+implementation
+
+function SplitString (s: string; delimiter: char): TStringArray;
+var
+  i: integer;
+  c: char;
+  part: string = '';
+  parts: TStringArray;
+begin
+  SetLength(parts, 0);
+  for i := 1 to Length(s) do
+    begin
+      c := s[i];
+      if (c = delimiter) or (i = Length(s)) then
+        begin
+          if (i = Length(s)) then
+            part += c;
+          SetLength(parts, Length(parts) + 1);
+          parts[High(parts)] := part;
+          part := '';
+        end
+      else
+        part += c;
+    end;
+  result := parts;
+end;
+
+function ParseParamList(RawList: String): TStringList;
+const
+  kPairDelimiter = ': ';
+var
+  Text: String = '';
+  I, J: Integer;
+  Types, Names, Pair: TStringArray;
+begin
+  Result := TStringList.Create;
+  // split types
+  Types := SplitString(RawList, ';');
+  for I := 0 to Length(Types) - 1 do
+    begin
+      // split name/type pair
+      Pair := SplitString(Types[I], ':');
+      if Length(Pair) <> 2 then
+        continue;
+
+      // split names
+      Names := SplitString(Pair[0], ',');
+      for J := 0 to Length(Names) - 1 do
+        Result.Add(Names[J]+kPairDelimiter+Pair[1]);
+      if Length(Names) > 0 then
+        continue;
+
+      Result.Add(Pair[0]+kPairDelimiter+Pair[1]);
+    end;
+end;
+
+function ParseParamList(RawList: String; AsSnippet: boolean): String;
+const
+  kParamDelimiter = ', ';
+  kPairDelimiter = ': ';
+var
+  Text: String = '';
+  CurrentIndex: Integer = 0;
+  I, J: Integer;
+  Types, Names, Pair: TStringArray;
+begin
+  // split types
+  Types := SplitString(RawList, ';');
+  for I := 0 to Length(Types) - 1 do
+    begin
+      // split name/type pair
+      Pair := SplitString(Types[I], ':');
+      if Length(Pair) <> 2 then
+        continue;
+
+      // split names
+      Names := SplitString(Pair[0], ',');
+      for J := 0 to Length(Names) - 1 do
+        begin
+          if AsSnippet then
+            Text += '${'+IntToStr(CurrentIndex + 1)+':'+Names[J]+kPairDelimiter+Pair[1]+'}'+kParamDelimiter
+          else
+            Text += Names[J]+kPairDelimiter+Pair[1]+kParamDelimiter;
+          Inc(CurrentIndex);
+        end;
+      if Length(Names) > 0 then
+        continue;
+
+      if AsSnippet then
+        Text += '${'+IntToStr(CurrentIndex + 1)+':'+Pair[0]+kPairDelimiter+Pair[1]+'}'+kParamDelimiter
+      else
+        Text += Pair[0]+kPairDelimiter+Pair[1]+kParamDelimiter;
+      Inc(CurrentIndex);
+    end;
+  
+  // trim trailing comma
+  Text := Trim(Text);
+  if (Length(Text) > 0) and (Text[Length(Text)] = ',') then
+    SetLength(Text, Length(Text) - 1);
+
+  Result := Text;
+end;
+
+end.
+

--- a/completion.pas
+++ b/completion.pas
@@ -348,8 +348,6 @@ begin with Params do
             begin
               Identifier := CodeToolBoss.IdentifierList.FilteredItems[I];
 
-              // TODO: currently the parsing is temporary also until we can 
-              // figure out how to use code tools properly
               if (TServerOption.InsertCompletionsAsSnippets in ServerSettings.Options) and 
                 Identifier.IsProcNodeWithParams then
                 begin

--- a/completion.pas
+++ b/completion.pas
@@ -403,9 +403,6 @@ begin with Params do
         end;
     end;
 
-    writeln(StdErr, 'Completions: ', Completions.count);
-    flush(stderr);
-
     Result.items := Completions;
   end;
 

--- a/completion.pas
+++ b/completion.pas
@@ -20,11 +20,12 @@
 unit completion;
 
 {$mode objfpc}{$H+}
+{$scopedenums on}
 
 interface
 
 uses
-  Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools,
+  Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools, CodeTree,
   lsp, basic;
 
 type
@@ -151,7 +152,7 @@ type
   published
     // The label of this completion item. By default also the text
     // that is inserted when selecting this completion.
-    property label_: string read fLabel write fLabel;
+    property &label: string read fLabel write fLabel;
     // The kind of this completion item. Based of the kind an icon is
     // chosen by the editor. The standardized set of available values
     // is defined in `CompletionItemKind`.
@@ -243,6 +244,74 @@ type
   end;
 
 implementation
+uses
+  SysUtils, Contnrs, PascalParserTool,
+  codeUtils, diagnostics, settings;
+  
+type
+  TIdentifierListItemHelper = class helper for TIdentifierListItem
+    function ParamPairList: string;
+    function ParamNameList: string;
+    function ParamTypeList: string;
+  end;
+
+function TIdentifierListItemHelper.ParamPairList: string;
+var
+  ANode: TCodeTreeNode;
+begin
+  Result:='';
+  ANode:=Node;
+  if (ANode<>nil) and (ANode.Desc=ctnProcedure) then begin
+    Result:=Tool.ExtractProcHead(ANode,
+       [phpWithoutClassKeyword,
+        phpWithoutClassName,
+        phpWithoutName,
+        phpWithParameterNames,
+        phpWithoutBrackets,
+        phpWithoutSemicolon,
+        phpDoNotAddSemicolon
+        ]);
+  end;
+end;
+
+function TIdentifierListItemHelper.ParamTypeList: string;
+var
+  ANode: TCodeTreeNode;
+begin
+  Result:='';
+  ANode:=Node;
+  if (ANode<>nil) and (ANode.Desc=ctnProcedure) then begin
+    Result:=Tool.ExtractProcHead(ANode,
+       [phpWithoutClassKeyword,
+        phpWithoutClassName,
+        phpWithoutName,
+        phpWithoutBrackets,
+        phpWithoutSemicolon,
+        phpDoNotAddSemicolon
+        ]);
+    Result:=StringReplace(Result, ',', '', []);
+  end;
+end;
+
+function TIdentifierListItemHelper.ParamNameList: string;
+var
+  ANode: TCodeTreeNode;
+begin
+  Result:='';
+  ANode:=Node;
+  if (ANode<>nil) and (ANode.Desc=ctnProcedure) then begin
+    Result:=Tool.ExtractProcHead(ANode,
+       [phpWithoutBrackets, 
+       phpWithoutClassKeyword,
+       phpWithoutClassName,
+       phpWithoutName,
+       phpWithoutSemicolon,
+       phpDoNotAddSemicolon,
+       phpWithoutParamTypes,
+       phpWithParameterNames
+       ]);
+  end;
+end;
 
 { TCompletion }
 
@@ -250,11 +319,13 @@ function TCompletion.Process(var Params: TCompletionParams): TCompletionList;
 var
   URI: TURI;
   Code: TCodeBuffer;
-  X, Y, PStart, PEnd, Count, I: Integer;
+  X, Y, PStart, PEnd, Count, I, J: Integer;
   Line: string;
   Completions: TCompletionItems;
   Identifier: TIdentifierListItem;
   Completion: TCompletionItem;
+  SnippetText, RawList: String;
+  IdentifierMap: TFPHashList;
 begin with Params do
   begin
     URI := ParseURI(textDocument.uri);
@@ -264,32 +335,81 @@ begin with Params do
     Line := Code.GetLine(Y);
     GetIdentStartEndAtPosition(Line, X + 1, PStart, PEnd);
     CodeToolBoss.IdentifierList.Prefix := Copy(Line, PStart, PEnd - PStart);
-
+    
+    IdentifierMap := TFPHashList.Create;
     Completions := TCompletionItems.Create;
-    if CodeToolBoss.GatherIdentifiers(Code,X + 1,Y + 1) then
-    begin
-      Count := CodeToolBoss.IdentifierList.GetFilteredCount;
-      for I := 0 to Count - 1 do
-      begin
-        Identifier := CodeToolBoss.IdentifierList.FilteredItems[I];
-        Completion := TCompletionItem(Completions.Add);
-        Completion.insertText := Identifier.Identifier;
-        Completion.detail:=Identifier.Node.DescAsString;
-        Completion.insertTextFormat := TInsertTextFormat.PlainText;
-      end;
-    end else begin
-      if CodeToolBoss.ErrorMessage<>'' then
-        writeln(stderr, 'Parse error: ',CodeToolBoss.ErrorMessage)
-      else
-        writeln(stderr, 'Error: no context');
+    Result := TCompletionList.Create;
+
+    try
+      if CodeToolBoss.GatherIdentifiers(Code,X + 1,Y + 1) then
+        begin
+          Count := CodeToolBoss.IdentifierList.GetFilteredCount;
+          for I := 0 to Count - 1 do
+            begin
+              Identifier := CodeToolBoss.IdentifierList.FilteredItems[I];
+
+              // TODO: currently the parsing is temporary also until we can 
+              // figure out how to use code tools properly
+              if (TServerOption.InsertCompletionsAsSnippets in ServerSettings.Options) and 
+                Identifier.IsProcNodeWithParams then
+                begin
+                  RawList := Identifier.ParamNameList;
+                  SnippetText := ParseParamList(RawList, True);
+                  Completion := TCompletionItem(Completions.Add);
+                  Completion.&label := Identifier.Identifier+'('+RawList+')';
+                  Completion.insertText := Identifier.Identifier+'('+SnippetText+');';
+                  Completion.insertTextFormat := TInsertTextFormat.Snippet;
+                  // according to LSP plugin devs filterText should be the identifier name
+                  // if the label contains non-alpha-numeric characters
+                  Completion.filterText := Identifier.Identifier;
+                  // this ensures the sort order is maintained in Sublime Text
+                  Completion.sortText := IntToStr(I);
+                end
+              else if IdentifierMap.Find(Identifier.Identifier) = nil then
+                begin
+                  Completion := TCompletionItem(Completions.Add);
+                  Completion.&label := Identifier.Identifier;
+                  Completion.detail := Identifier.Node.DescAsString;
+                  if (TServerOption.InsertCompletionProcedureBrackets in ServerSettings.Options) and 
+                    Identifier.IsProcNodeWithParams then
+                    begin
+                      Completion.insertText := Identifier.Identifier+'($0)';
+                      Completion.insertTextFormat := TInsertTextFormat.Snippet;
+                    end
+                  else
+                    begin
+                      Completion.insertText := Identifier.Identifier;
+                      Completion.insertTextFormat := TInsertTextFormat.PlainText;
+                    end;
+                  // this ensures the sort order is maintained in Sublime Text
+                  Completion.sortText := IntToStr(I);
+                  IdentifierMap.Add(Identifier.Identifier, Identifier);
+                end;
+            end;
+        end else begin
+          //if CodeToolBoss.ErrorMessage<>'' then
+          //  writeln(stderr, 'Parse error: ',CodeToolBoss.ErrorMessage)
+          //else
+          //  writeln(StdErr, 'Error: no context');
+          PublishCodeToolsError;
+          Flush(StdErr);
+          Result.isIncomplete := true;
+        end;
+    except
+      on E: Exception do
+        begin
+          writeln(StdErr, 'Completion Error: ', E.ClassName, ' ', E.Message);
+          flush(StdErr);
+          Result.isIncomplete := true;
+        end;
     end;
 
-    Result := TCompletionList.Create;
     Result.items := Completions;
   end;
+
+  FreeAndNil(IdentifierMap);
 end;
 
 initialization
   LSPHandlerManager.RegisterHandler('textDocument/completion', TCompletion);
 end.
-

--- a/completion.pas
+++ b/completion.pas
@@ -246,7 +246,7 @@ type
 implementation
 uses
   SysUtils, Contnrs, PascalParserTool,
-  codeUtils, diagnostics, settings;
+  codeUtils, settings;
   
 type
   TIdentifierListItemHelper = class helper for TIdentifierListItem
@@ -387,12 +387,10 @@ begin with Params do
                 end;
             end;
         end else begin
-          //if CodeToolBoss.ErrorMessage<>'' then
-          //  writeln(stderr, 'Parse error: ',CodeToolBoss.ErrorMessage)
-          //else
-          //  writeln(StdErr, 'Error: no context');
-          PublishCodeToolsError;
-          Flush(StdErr);
+          if CodeToolBoss.ErrorMessage<>'' then
+            writeln(stderr, 'Parse error: ',CodeToolBoss.ErrorMessage)
+          else
+            writeln(StdErr, 'Error: no context');
           Result.isIncomplete := true;
         end;
     except

--- a/completion.pas
+++ b/completion.pas
@@ -391,6 +391,7 @@ begin with Params do
             writeln(stderr, 'Parse error: ',CodeToolBoss.ErrorMessage)
           else
             writeln(StdErr, 'Error: no context');
+          Flush(stderr);
           Result.isIncomplete := true;
         end;
     except
@@ -401,6 +402,9 @@ begin with Params do
           Result.isIncomplete := true;
         end;
     end;
+
+    writeln(StdErr, 'Completions: ', Completions.count);
+    flush(stderr);
 
     Result.items := Completions;
   end;

--- a/options.pas
+++ b/options.pas
@@ -60,9 +60,18 @@ type
     property change: TTextDocumentSyncKind read fChange write fChange;
   end;
 
+  { TSignatureHelpOptions }
+  
+  TSignatureHelpOptions = class(TPersistent)
+  private
+    fTriggerCharacters: TStrings;
+  published
+    // The characters that trigger signature help automatically.
+    property triggerCharacters: TStrings read fTriggerCharacters write fTriggerCharacters;
+  end;
+
   { TCompletionOptions }
 
-  // Completion options.
   TCompletionOptions = class(TPersistent)
   private
     fTriggerCharacters: TStrings;
@@ -117,4 +126,3 @@ begin
 end;
 
 end.
-

--- a/options.pas
+++ b/options.pas
@@ -91,9 +91,9 @@ type
     // If a server provides both `allCommitCharacters` and commit
     // characters on an individual completion item the ones on the
     // completion item win.
-    //
-    // @since 3.2.0
+    {$if LSP >= 3015}
     property allCommitCharacters: TStrings read fAllCommitCharacters write fAllCommitCharacters;
+    {$endif}
     // The server provides support to resolve additional information
     // for a completion item.
     property resolveProvider: Boolean read fResolveProvider write fResolveProvider;

--- a/pasls.lpi
+++ b/pasls.lpi
@@ -118,5 +118,13 @@
         <UseExternalDbgSyms Value="True"/>
       </Debugging>
     </Linking>
+    <Other>
+      <Verbosity>
+        <ShowWarn Value="True"/>
+        <ShowNotes Value="False"/>
+        <ShowHints Value="False"/>
+      </Verbosity>
+      <CustomOptions Value="-dLSP:=3014"/>
+    </Other>
   </CompilerOptions>
 </CONFIG>

--- a/pasls.lpr
+++ b/pasls.lpr
@@ -65,6 +65,16 @@ begin
     Response := Dispatcher.Execute(Request);
     if Assigned(Response) then
     begin
+      // invalid responses without id's or null id's must not be sent to server, i.e:
+      // {"jsonrpc":"2.0","error":{"code":-32603,"message":"Access violation"},"id":null}
+      if (Response is TJSONObject) and 
+        ((TJSONObject(Response).Find('id') = nil) or 
+          TJSONObject(Response).Nulls['id']) then
+        begin
+          Writeln(StdErr, 'invalid response -> ', response.AsJSON, ' from request ',  Content);
+          Flush(StdErr);
+          continue;
+        end;
       Content := Response.AsJSON;
       WriteLn('Content-Type: ', ContentType);
       WriteLn('Content-Length: ', Content.Length);

--- a/pasls.lpr
+++ b/pasls.lpr
@@ -20,6 +20,9 @@
 program pasls;
 
 {$mode objfpc}{$H+}
+{$ifndef LSP}
+{$error LSP macro must be set with current API version number, i.e. LSP:=3014 for API 3.14}
+{$endif}
 
 uses
   SysUtils, fpjson, jsonparser, jsonscanner,

--- a/settings.pas
+++ b/settings.pas
@@ -1,5 +1,5 @@
 // Pascal Language Server
-// Copyright 2020 Arjan Adriaanse
+// Copyright 2020 Ryan Joseph
 
 // This file is part of Pascal Language Server.
 

--- a/settings.pas
+++ b/settings.pas
@@ -1,0 +1,46 @@
+// Pascal Language Server
+// Copyright 2020 Arjan Adriaanse
+
+// This file is part of Pascal Language Server.
+
+// Pascal Language Server is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation, either version 3 of
+// the License, or (at your option) any later version.
+
+// Pascal Language Server is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Pascal Language Server.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+unit settings;
+
+{$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
+{$scopedenums on}
+
+interface
+
+type
+  TServerOption = (
+      InsertCompletionsAsSnippets,        // Procedure completions with parameters are inserted as snippets
+      InsertCompletionProcedureBrackets   // Procedure completions with parameters (non-snippet) insert
+                                          // empty brackets (and insert as snippet)
+    );
+  TServerOptions = set of TServerOption;
+  
+  TServerSettings = record
+    MainProgramFile: String;
+    Options: TServerOptions;
+  end;
+
+var
+  ServerSettings: TServerSettings;
+
+implementation
+
+end.

--- a/settings.pas
+++ b/settings.pas
@@ -34,7 +34,6 @@ type
   TServerOptions = set of TServerOption;
   
   TServerSettings = record
-    MainProgramFile: String;
     Options: TServerOptions;
   end;
 


### PR DESCRIPTION
Ok Arjan I've moved all my changes to a "trunk" branch and I guess I'll start moving them over in pieces to this "pending" branch so we can talk about it before merging them in. I've implemented a large number of requests but there's too much to just throw at you now (and some is in dev states, like document/workspace symbols)

For this I've improved completions and did some tests with inserting as snippets (for functions) which are currently buggy in Sublime Text but they'll address that later. 

Across my changes I've decided we need some settings which the user can provide with initializationOptions. Completions for example shouldn't be snippets unless the user actually wants that. Currently however I've just added them in a global record (not sure if that's ok with you) and I haven't actually streamed them so they're off until I get to that point.

There's probably better ways to use code tools but I couldn't figure everything out so I included a codeUtils unit which is helping me do additional parsing (yes, we shouldn't have do this extra step). I'll do that right later once I know how. :)