### PR TITLE
Fix memory leaks

### DIFF
--- a/capabilities.pas
+++ b/capabilities.pas
@@ -24,7 +24,7 @@ unit capabilities;
 interface
 
 uses
-  Classes, options;
+  SysUtils, Classes, options;
 
 type
 
@@ -50,6 +50,8 @@ type
   private
     fWorkspace: TWorkspaceClientCapabilities;
     fTextDocument: TTextDocumentClientCapabilities;
+  public
+    destructor Destroy; override;
   published
     property workspace: TWorkspaceClientCapabilities read fWorkspace write fWorkspace;
     property textDocument: TTextDocumentClientCapabilities read fTextDocument write fTextDocument;
@@ -63,6 +65,7 @@ type
     fCompletionProvider: TCompletionOptions;
   public
     constructor Create;
+    destructor Destroy; override;
   published
     property textDocumentSync: TTextDocumentSyncOptions read fTextDocumentSync write fTextDocumentSync;
     property completionProvider: TCompletionOptions read fCompletionProvider write fCompletionProvider;
@@ -70,12 +73,29 @@ type
 
 implementation
 
+{ TClientCapabilities }
+
+destructor TClientCapabilities.Destroy;
+begin
+  FreeAndNil(fWorkspace);
+  FreeAndNil(fTextDocument);
+  inherited Destroy;
+end;
+
 { TServerCapabilities }
 
 constructor TServerCapabilities.Create;
 begin
   textDocumentSync := TTextDocumentSyncOptions.Create;
   completionProvider := TCompletionOptions.Create;
+end;
+
+destructor TServerCapabilities.Destroy;
+begin
+  FreeAndNil(fTextDocumentSync);
+  FreeAndNil(fCompletionProvider);
+
+  inherited Destroy;
 end;
 
 end.

--- a/completion.pas
+++ b/completion.pas
@@ -24,7 +24,7 @@ unit completion;
 interface
 
 uses
-  Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools,
+  SysUtils, Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools,
   lsp, basic;
 
 type
@@ -66,6 +66,8 @@ type
   TCompletionParams = class(TTextDocumentPositionParams)
   private
     fContext: TCompletionContext;
+  public
+    destructor Destroy; override;
   published
     // The completion context. This is only available if the client
     // specifies to send this using
@@ -148,6 +150,8 @@ type
     fTextEdit: TTextEdit;
     fAdditionalTextEdits: TTextEdits;
     fCommitCharacters: TStrings;
+  public
+    destructor Destroy; override;
   published
     // The label of this completion item. By default also the text
     // that is inserted when selecting this completion.
@@ -228,6 +232,8 @@ type
   private
     fIsIncomplete: Boolean;
     fItems: TCompletionItems;
+  public
+    destructor Destroy; override;
   published
     // This list it not complete. Further typing should result in
     // recomputing this list.
@@ -243,6 +249,32 @@ type
   end;
 
 implementation
+
+{ TCompletionParams }
+
+destructor TCompletionParams.Destroy;
+begin
+  FreeAndNil(fContext);
+  inherited Destroy;
+end;
+
+{ TCompletionItem }
+
+destructor TCompletionItem.Destroy;
+begin
+  FreeAndNil(fAdditionalTextEdits);
+  FreeAndNil(fCommitCharacters);
+  FreeAndNil(fDocumentation);
+  inherited Destroy;
+end;
+
+{ TCompletionList }
+
+destructor TCompletionList.Destroy;
+begin
+  FreeAndNil(fItems);
+  inherited Destroy;
+end;
 
 { TCompletion }
 

--- a/options.pas
+++ b/options.pas
@@ -24,7 +24,7 @@ unit options;
 interface
 
 uses
-  Classes;
+  SysUtils, Classes;
 
 type
 

--- a/pasls.lpr
+++ b/pasls.lpr
@@ -72,5 +72,10 @@ begin
       Write(Content);
       Flush(Output);
     end;
+
+    FreeAndNil(Request);
+    FreeAndNil(Response);
   end;
+
+  FreeAndNil(Dispatcher);
 end.

--- a/synchronization.pas
+++ b/synchronization.pas
@@ -24,7 +24,7 @@ unit synchronization;
 interface
 
 uses
-  Classes, URIParser, CodeToolManager, CodeCache,
+  SysUtils, Classes, URIParser, CodeToolManager, CodeCache,
   lsp, basic;
 
 type
@@ -34,6 +34,8 @@ type
   TDidOpenTextDocumentParams = class(TPersistent)
   private
     fTextDocument: TTextDocumentItem;
+  public
+    destructor Destroy; override;
   published
     // The document that was opened.
     property textDocument: TTextDocumentItem read fTextDocument write fTextDocument;
@@ -66,6 +68,7 @@ type
     fContentChanges: TCollection;
   public
     constructor Create;
+    destructor Destroy; override;
   published
     // The document that did change. The version number points to the
     // version after all provided content changes have been applied.
@@ -95,11 +98,26 @@ type
 
 implementation
 
+{ TDidOpenTextDocumentParams }
+
+destructor TDidOpenTextDocumentParams.Destroy;
+begin
+  FreeAndNil(fTextDocument);
+  inherited Destroy;
+end;
+
 { TDidChangeTextDocumentParams }
 
 constructor TDidChangeTextDocumentParams.Create;
 begin
   contentChanges := TCollection.Create(TTextDocumentContentChangeEvent);
+end;
+
+destructor TDidChangeTextDocumentParams.Destroy;
+begin
+  FreeAndNil(fTextDocument);
+  FreeAndNil(fContentChanges);
+  inherited Destroy;
 end;
 
 { TDidOpenTextDocument }


### PR DESCRIPTION
With every keystroke the program creates a bunch of objects which are never being freed. Pascal is not a garbage-collected language, so these objects will pile up and the process will eventually run out of memory. This is not good.

Here's my attempt at fixing this. I can't guarantee that I found every leak, but at least it should be an improvement.

For the future, I would recommend getting into the habit of writing the cleanup code immediately. It's a lot harder to identify those kinds of leaks later and you are much more likely to overlook something.

Closes #2