### PR TITLE
TCompletionItem: Rename `label_` to `&label`

### DIFF
--- a/capabilities.pas
+++ b/capabilities.pas
@@ -24,7 +24,7 @@ unit capabilities;
 interface
 
 uses
-  Classes, options;
+  SysUtils, Classes, options;
 
 type
 
@@ -50,6 +50,8 @@ type
   private
     fWorkspace: TWorkspaceClientCapabilities;
     fTextDocument: TTextDocumentClientCapabilities;
+  public
+    destructor Destroy; override;
   published
     property workspace: TWorkspaceClientCapabilities read fWorkspace write fWorkspace;
     property textDocument: TTextDocumentClientCapabilities read fTextDocument write fTextDocument;
@@ -63,6 +65,7 @@ type
     fCompletionProvider: TCompletionOptions;
   public
     constructor Create;
+    destructor Destroy; override;
   published
     property textDocumentSync: TTextDocumentSyncOptions read fTextDocumentSync write fTextDocumentSync;
     property completionProvider: TCompletionOptions read fCompletionProvider write fCompletionProvider;
@@ -70,12 +73,29 @@ type
 
 implementation
 
+{ TClientCapabilities }
+
+destructor TClientCapabilities.Destroy;
+begin
+  FreeAndNil(fWorkspace);
+  FreeAndNil(fTextDocument);
+  inherited Destroy;
+end;
+
 { TServerCapabilities }
 
 constructor TServerCapabilities.Create;
 begin
   textDocumentSync := TTextDocumentSyncOptions.Create;
   completionProvider := TCompletionOptions.Create;
+end;
+
+destructor TServerCapabilities.Destroy;
+begin
+  FreeAndNil(fTextDocumentSync);
+  FreeAndNil(fCompletionProvider);
+
+  inherited Destroy;
 end;
 
 end.

--- a/completion.pas
+++ b/completion.pas
@@ -24,7 +24,7 @@ unit completion;
 interface
 
 uses
-  Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools,
+  SysUtils, Classes, URIParser, CodeToolManager, CodeCache, IdentCompletionTool, BasicCodeTools,
   lsp, basic;
 
 type
@@ -66,6 +66,8 @@ type
   TCompletionParams = class(TTextDocumentPositionParams)
   private
     fContext: TCompletionContext;
+  public
+    destructor Destroy; override;
   published
     // The completion context. This is only available if the client
     // specifies to send this using
@@ -148,6 +150,8 @@ type
     fTextEdit: TTextEdit;
     fAdditionalTextEdits: TTextEdits;
     fCommitCharacters: TStrings;
+  public
+    destructor Destroy; override;
   published
     // The label of this completion item. By default also the text
     // that is inserted when selecting this completion.
@@ -228,6 +232,8 @@ type
   private
     fIsIncomplete: Boolean;
     fItems: TCompletionItems;
+  public
+    destructor Destroy; override;
   published
     // This list it not complete. Further typing should result in
     // recomputing this list.
@@ -243,6 +249,32 @@ type
   end;
 
 implementation
+
+{ TCompletionParams }
+
+destructor TCompletionParams.Destroy;
+begin
+  FreeAndNil(fContext);
+  inherited Destroy;
+end;
+
+{ TCompletionItem }
+
+destructor TCompletionItem.Destroy;
+begin
+  FreeAndNil(fAdditionalTextEdits);
+  FreeAndNil(fCommitCharacters);
+  FreeAndNil(fDocumentation);
+  inherited Destroy;
+end;
+
+{ TCompletionList }
+
+destructor TCompletionList.Destroy;
+begin
+  FreeAndNil(fItems);
+  inherited Destroy;
+end;
 
 { TCompletion }
 

--- a/completion.pas
+++ b/completion.pas
@@ -155,7 +155,7 @@ type
   published
     // The label of this completion item. By default also the text
     // that is inserted when selecting this completion.
-    property label_: string read fLabel write fLabel;
+    property &label: string read fLabel write fLabel;
     // The kind of this completion item. Based of the kind an icon is
     // chosen by the editor. The standardized set of available values
     // is defined in `CompletionItemKind`.

--- a/options.pas
+++ b/options.pas
@@ -24,7 +24,7 @@ unit options;
 interface
 
 uses
-  Classes;
+  SysUtils, Classes;
 
 type
 

--- a/pasls.lpr
+++ b/pasls.lpr
@@ -72,5 +72,10 @@ begin
       Write(Content);
       Flush(Output);
     end;
+
+    FreeAndNil(Request);
+    FreeAndNil(Response);
   end;
+
+  FreeAndNil(Dispatcher);
 end.

--- a/synchronization.pas
+++ b/synchronization.pas
@@ -24,7 +24,7 @@ unit synchronization;
 interface
 
 uses
-  Classes, URIParser, CodeToolManager, CodeCache,
+  SysUtils, Classes, URIParser, CodeToolManager, CodeCache,
   lsp, basic;
 
 type
@@ -34,6 +34,8 @@ type
   TDidOpenTextDocumentParams = class(TPersistent)
   private
     fTextDocument: TTextDocumentItem;
+  public
+    destructor Destroy; override;
   published
     // The document that was opened.
     property textDocument: TTextDocumentItem read fTextDocument write fTextDocument;
@@ -66,6 +68,7 @@ type
     fContentChanges: TCollection;
   public
     constructor Create;
+    destructor Destroy; override;
   published
     // The document that did change. The version number points to the
     // version after all provided content changes have been applied.
@@ -95,11 +98,26 @@ type
 
 implementation
 
+{ TDidOpenTextDocumentParams }
+
+destructor TDidOpenTextDocumentParams.Destroy;
+begin
+  FreeAndNil(fTextDocument);
+  inherited Destroy;
+end;
+
 { TDidChangeTextDocumentParams }
 
 constructor TDidChangeTextDocumentParams.Create;
 begin
   contentChanges := TCollection.Create(TTextDocumentContentChangeEvent);
+end;
+
+destructor TDidChangeTextDocumentParams.Destroy;
+begin
+  FreeAndNil(fTextDocument);
+  FreeAndNil(fContentChanges);
+  inherited Destroy;
 end;
 
 { TDidOpenTextDocument }


### PR DESCRIPTION
Since `label` is a reserved word in Pascal, the class `TCompletionItem` uses `label_` as a property name. Unfortunately, this means that the serialized JSON also contains the key `label_` instead of `label`. This confuses language server clients expecting the key `label`. For example, `completion-nvim` crashes.

A simple workaround is to escape the reserved word with `&`. This way, the correct JSON output will be generated.